### PR TITLE
Add stubs for subcommands

### DIFF
--- a/optimiser-digital-twin/src/main/java/eu/nebulouscloud/optimiser/twin/DeploymentImporter.java
+++ b/optimiser-digital-twin/src/main/java/eu/nebulouscloud/optimiser/twin/DeploymentImporter.java
@@ -1,0 +1,27 @@
+package eu.nebulouscloud.optimiser.twin;
+
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import groovyjarjarpicocli.CommandLine.ParentCommand;
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Slf4j
+@Command(name = "import-deployment",
+    description = "Create deployment database from solver solution",
+    mixinStandardHelpOptions = true)
+public class DeploymentImporter implements Callable<Integer> {
+    @ParentCommand
+    private App app;
+
+    @Parameters(description = "A file containing a solver message with machine configurations")
+    private Path configurationFile;
+
+    @Override
+    public Integer call() {
+        System.out.println("Import deployment configuration " + configurationFile + " ...");
+        return 0;
+    }
+}

--- a/optimiser-digital-twin/src/main/java/eu/nebulouscloud/optimiser/twin/Server.java
+++ b/optimiser-digital-twin/src/main/java/eu/nebulouscloud/optimiser/twin/Server.java
@@ -1,0 +1,86 @@
+package eu.nebulouscloud.optimiser.twin;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+import picocli.CommandLine.ParentCommand;
+
+@Slf4j
+@Command(name = "serve",
+    aliases = {"s"},
+    description = "Start microservice in the NebulOuS platform",
+    mixinStandardHelpOptions = true)
+public class Server implements Callable<Integer> {
+
+    /** Reference to main app set up by PicoCLI.  This lets us ask for the
+      * ActiveMQ connector. */
+    @ParentCommand
+    private App app;
+
+    @Option(names = {"--activemq-host"},
+            description = "The hostname of the ActiveMQ server.  Can also be set via the @|bold ACTIVEMQ_HOST|@ environment variable.",
+            paramLabel = "ACTIVEMQ_HOST",
+            defaultValue = "${ACTIVEMQ_HOST:-localhost}")
+    private String activemq_host;
+
+    @Option(names = {"--activemq-port"},
+            description = "The port of the ActiveMQ server.  Can also be set via the @|bold ACTIVEMQ_PORT|@ environment variable.",
+            paramLabel = "ACTIVEMQ_PORT",
+            defaultValue = "${ACTIVEMQ_PORT:-5672}")
+    private int activemq_port;
+
+    @Option(names = {"--activemq-user"},
+            description = "The user name for the ActiveMQ server. Can also be set via the @|bold ACTIVEMQ_USER|@ environment variable.",
+            paramLabel = "ACTIVEMQ_USER",
+            defaultValue = "${ACTIVEMQ_USER}")
+    private String activemq_user;
+
+    @Option(names = {"--activemq-password"},
+            description = "The password for the ActiveMQ server. Can also be set via the @|bold ACTIVEMQ_PASSWORD|@ environment variable.",
+            paramLabel = "ACTIVEMQ_PASSWORD",
+            defaultValue = "${ACTIVEMQ_PASSWORD}")
+    private String activemq_password;
+
+    /**
+     * The ActiveMQ connector.
+     *
+     * @return the ActiveMQ connector wrapper, or null if running offline.
+     */
+    @Getter
+    private static ExnConnector activeMQConnector = null;
+
+    @Override
+    public Integer call() {
+        // Start connection to ActiveMQ if possible.
+        if (activemq_user != null && activemq_password != null) {
+            log.info("Preparing ActiveMQ connection: host={} port={}",
+                activemq_host, activemq_port);
+            activeMQConnector
+              = new ExnConnector(activemq_host, activemq_port,
+                  activemq_user, activemq_password);
+        } else {
+            log.debug("ActiveMQ login info not set, only operating locally.");
+        }
+        CountDownLatch exn_synchronizer = new CountDownLatch(1);
+        if (activeMQConnector != null) {
+            log.debug("Starting connection to ActiveMQ");
+            activeMQConnector.start(exn_synchronizer);
+        } else {
+            log.error("ActiveMQ connector not initialized so we're unresponsive. Will keep running to keep CI/CD happy but don't expect anything more from me.");
+        }
+        // Note that we try to synchronize, even if we didn't connect to
+        // ActiveMQ.  This is so that the container can be deployed.  (If the
+        // container terminates, the build registers as unsuccessful.)
+        log.info("Optimiser-digital-twin initialization complete, waiting for messages");
+        try {
+            exn_synchronizer.await();
+        } catch (InterruptedException e) {
+            // ignore
+        }
+        return 0;
+    }
+}

--- a/optimiser-digital-twin/src/main/java/eu/nebulouscloud/optimiser/twin/Simulator.java
+++ b/optimiser-digital-twin/src/main/java/eu/nebulouscloud/optimiser/twin/Simulator.java
@@ -1,0 +1,24 @@
+package eu.nebulouscloud.optimiser.twin;
+
+import java.util.concurrent.Callable;
+
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.ParentCommand;
+
+@Slf4j
+@Command(name = "simulate",
+    description = "Execute one simulation run",
+    mixinStandardHelpOptions = true)
+public class Simulator implements Callable<Integer> {
+
+    @ParentCommand
+    private App app;
+
+    @Override
+    public Integer call() throws Exception {
+        System.out.println("Running simulation ...");
+        return 0;
+    }
+
+}

--- a/optimiser-digital-twin/src/main/java/eu/nebulouscloud/optimiser/twin/TraceImporter.java
+++ b/optimiser-digital-twin/src/main/java/eu/nebulouscloud/optimiser/twin/TraceImporter.java
@@ -1,0 +1,29 @@
+package eu.nebulouscloud.optimiser.twin;
+
+import java.nio.file.Path;
+import java.util.concurrent.Callable;
+
+import lombok.extern.slf4j.Slf4j;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+import picocli.CommandLine.ParentCommand;
+
+@Slf4j
+@Command(name = "import-traces",
+    description = "Create trace database from server log file",
+    mixinStandardHelpOptions = true)
+public class TraceImporter implements Callable<Integer> {
+
+    @ParentCommand
+    private App app;
+
+    @Parameters(description = "A file containing trace logs")
+    private Path traceFile;
+
+    @Override
+    public Integer call() throws Exception {
+        System.out.println("Import trace file " + traceFile + " ...");
+        return 0;
+    }
+
+}

--- a/optimiser-digital-twin/src/test/java/eu/nebulouscloud/optimiser/twin/AppTest.java
+++ b/optimiser-digital-twin/src/test/java/eu/nebulouscloud/optimiser/twin/AppTest.java
@@ -17,7 +17,7 @@ class AppTest {
         PrintStream originalOut = System.out;
         try {
             System.setOut(printStream);
-            Hello.Main.main(new String[0]);
+            Twin.Main.main(new String[0]);
         } finally {
             System.setOut(originalOut);
         }


### PR DESCRIPTION
For deployment:
- `serve`: run NebulOuS microservice

For local execution and testing:
- `import-deployment`: create deployment database
- `import-traces`: create traces database
- `simulate`: run one simulation round